### PR TITLE
Fix Slack invitation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Cette communautée rassemble les rubyistes nantais autour de Ruby et de son éco
 Vous voulez apprendre plein de choses autour de Ruby ? Rencontrer et prendre l'apéro avec des passionnés de cette technologie ? Ça se passe une fois par mois autour d'un Meetup. Retrouvez le prochain sur :
 https://www.meetup.com/fr-FR/Nantes-rb/
 
-### 💬 Discutez avec nous sur [Slack](https://nantesrb.herokuapp.com/)
-Trouver des réponses à ses questions Ruby ? Participer aux projets de la communauté ? Notre Slack est ouvert à tous : https://nantesrb.herokuapp.com/
+### 💬 Discutez avec nous sur [Slack](https://join.slack.com/t/nantesrb/shared_invite/enQtNjg2MDM5NzQzNjE4LTQzMjg2NTc1MWZjZDY5N2Q3NTY1Y2M0NDI0ZTYxYjBmNWJkNTdlYjc5ZjAyYWQ0YTRiMTY2MTQ0YWM4MTFlNzQ)
+Trouver des réponses à ses questions Ruby ? Participer aux projets de la communauté ? Notre Slack est ouvert à tous : [https://join.slack.com/t/nantesrb/shared_invite/enQtNj...](https://join.slack.com/t/nantesrb/shared_invite/enQtNjg2MDM5NzQzNjE4LTQzMjg2NTc1MWZjZDY5N2Q3NTY1Y2M0NDI0ZTYxYjBmNWJkNTdlYjc5ZjAyYWQ0YTRiMTY2MTQ0YWM4MTFlNzQ)
 
 ### 🐦 Suivez notre actualité sur [Twitter](https://twitter.com/nantesrb)
 Pour ne pas rater les évenements Ruby de la région, suivez notre compte Twitter :


### PR DESCRIPTION
Le lien actuel pointe vers une app Heroku qui n'existe plus.
Je l'ai remplacé par le lien d'invite trouvé sur le site de Nantes.rb